### PR TITLE
:fix: convert to unaware datetimes

### DIFF
--- a/pysolar/numeric.py
+++ b/pysolar/numeric.py
@@ -31,6 +31,8 @@ To force builtins math module usage when numpy is available:
 from math import degrees, cos, sin, radians, tan, pi
 from math import acos, atan, asin, atan2, exp, e
 
+from datetime import timezone
+
 current_mod = 'math'
 
 
@@ -52,6 +54,12 @@ def where_math(condition, x, y):
 where = where_math
 
 
+def convert_to_unaware_datetime(dt):
+    if hasattr(dt, 'tzinfo') and dt.tzinfo is not None:
+        dt = dt.astimezone(timezone.utc).replace(tzinfo=None)
+    return dt
+
+
 def tm_yday_math(d):
     return d.utctimetuple().tm_yday
 
@@ -59,6 +67,7 @@ tm_yday = tm_yday_math
 
 
 def tm_yday_numpy(d):
+    d = convert_to_unaware_datetime(d)
     dd = numpy.array(d, dtype='datetime64[D]')
     dy = numpy.array(d, dtype='datetime64[Y]')
     return (dd - dy).astype('int') + 1
@@ -71,6 +80,7 @@ tm_hour = tm_hour_math
 
 
 def tm_hour_numpy(d):
+    d = convert_to_unaware_datetime(d)
     dh = numpy.array(d, dtype='datetime64[h]')
     dd = numpy.array(d, dtype='datetime64[D]')
     return (dh - dd).astype('int')
@@ -83,6 +93,7 @@ tm_min = tm_min_math
 
 
 def tm_min_numpy(d):
+    d = convert_to_unaware_datetime(d)
     dm = numpy.array(d, dtype='datetime64[m]')
     dh = numpy.array(d, dtype='datetime64[h]')
     return (dm - dh).astype('int')


### PR DESCRIPTION
The numpy conversion in numeric.py to datetime64 with timezone aware datetimes is [deprecated](https://numpy.org/doc/stable/reference/arrays.datetime.html?highlight=datetime64#changes-with-numpy-1-11). On the other hand the functions in [solar.py](https://github.com/MeteoGroup/pysolar/blob/master/pysolar/solar.py) use the [`check_aware_dt`](https://github.com/MeteoGroup/pysolar/blob/master/pysolar/tzinfo_check.py#L20) decorator to ensure that the date argument is aware.